### PR TITLE
Ckan resource auth

### DIFF
--- a/ckanpackager/tasks/datastore_package_task.py
+++ b/ckanpackager/tasks/datastore_package_task.py
@@ -26,7 +26,8 @@ class DatastorePackageTask(PackageTask):
             'limit': (False, None, True),
             'offset': (False, None, True),
             'fields': (False, None, True),
-            'sort': (False, None, True)
+            'sort': (False, None, True),
+            'key': (False, None, False)
         }
 
     def host(self):

--- a/ckanpackager/tasks/url_package_task.py
+++ b/ckanpackager/tasks/url_package_task.py
@@ -12,7 +12,8 @@ class UrlPackageTask(PackageTask):
         return {
             'resource_id': (True, None),
             'email': (True, None),
-            'resource_url': (True, None)
+            'resource_url': (True, None),
+            'key': (False, None)
         }
 
     def host(self):
@@ -28,9 +29,14 @@ class UrlPackageTask(PackageTask):
 
         @return: The ZIP file name
         """
+        headers = {}
+        if 'key' in self.request_params:
+            headers['Authorization'] = self.request_params['key']
         try:
             output_stream = resource.get_writer()
-            input_stream = urllib2.urlopen(self.request_params['resource_url'])
+            request = urllib2.Request(self.request_params['resource_url'],
+                                      headers=headers)
+            input_stream = urllib2.urlopen(request)
             self.log.info("Fetching and saving file.")
             shutil.copyfileobj(input_stream, output_stream)
             resource.create_zip(self.config['ZIP_COMMAND'])

--- a/ckanpackager/tests/test_url_package_task.py
+++ b/ckanpackager/tests/test_url_package_task.py
@@ -83,3 +83,19 @@ class TestUrlPackageTask(object):
         r = DummyResource()
         self._task.create_zip(r)
         assert_true(r.clean_invoked)
+
+    @httpretty.activate
+    def test_request_authorization(self):
+        """Ensure an authorization header is added"""
+        apikey = 'some_api_key'
+        task = UrlPackageTask({
+            'resource_id': 'the-resource-id',
+            'resource_url': 'http://example.com/the/resource/url.txt',
+            'email': 'someone@0.0.0.0',
+            'key': apikey
+        }, self._config)
+        r = DummyResource()
+        task.create_zip(r)
+        assert_true(r.clean_invoked)
+        headers = dict(httpretty.last_request().headers)
+        assert_equals(headers['authorization'], apikey)


### PR DESCRIPTION
This PR allows an authorization header to be passed through to the main CKAN instance so that private dataset resources can be accessed and packaged. This applies to all types of resource package tasks (url, datastore and DwC).