### PR TITLE
Include formats in the multimedia.csv export

### DIFF
--- a/ckanpackager/config_defaults.py
+++ b/ckanpackager/config_defaults.py
@@ -37,6 +37,12 @@ DWC_EXTENSION_FIELDS = {
             'title': '',
             'license': '',
             'rightsHolder': ''
+        },
+        'mappings': {
+            'format': 'mime'
+        },
+        'formatters': {
+            'format': lambda v: 'image/{}'.format(v) if v else v
         }
     }
 }

--- a/ckanpackager/lib/dwc_archive_structure.py
+++ b/ckanpackager/lib/dwc_archive_structure.py
@@ -14,7 +14,7 @@ class DwcArchiveStructure(object):
         if name not in self._extensions:
             self._extensions[name] = OrderedDict()
 
-    def add_term(self, input_field, ext_field, extension, term_name):
+    def add_term(self, input_field, ext_field, extension, term_name, formatter):
         """Add a new term to the archive structure
 
         @param input_field: The input field matching this term
@@ -22,12 +22,13 @@ class DwcArchiveStructure(object):
                           that
         @param extension: The extension in the archive structure
         @param term_name: The field name in the archive structure
+        @param formatter: The formatter for this field, if there is one, if not this will be None
         """
         self.add_extension(extension)
         if term_name not in self._extensions[extension]:
             self._extensions[extension][term_name] = []
-        if (input_field, ext_field) not in self._extensions[extension][term_name]:
-            self._extensions[extension][term_name].append((input_field, ext_field))
+        if (input_field, ext_field, formatter) not in self._extensions[extension][term_name]:
+            self._extensions[extension][term_name].append((input_field, ext_field, formatter))
 
     def extensions(self):
         """Return the list of extensions

--- a/deployment/ckanpackager_settings.py
+++ b/deployment/ckanpackager_settings.py
@@ -116,6 +116,18 @@ DWC_EXTENSION_FIELDS = {
             'title': '',
             'license': 'http://creativecommons.org/licenses/by/4.0/',
             'rightsHolder': ''
+        },
+        # this defines a mapping from DwC extension term name to the field name used
+        # in the datastore search result (i.e. associatedMedia.mime -> format
+        'mappings': {
+            # in the associatedMedia field that comes back from solr, the
+            # format is stored under the key mime
+            'format': 'mime'
+        },
+        # this defines formatting functions that should be used on any given terms
+        'formatters': {
+            # the format needs to start with image/
+            'format': lambda v: 'image/{}'.format(v) if v else v
         }
     }
 }


### PR DESCRIPTION
This change means we now export a multimedia format in the multimedia.csv output. This is achieved by providing a mapping and a formatter for the format term.

Closes https://github.com/NaturalHistoryMuseum/ckanext-nhm/issues/398