### PR TITLE
Only output archive files and metadata if the data exists

### DIFF
--- a/ckanpackager/lib/resource_file.py
+++ b/ckanpackager/lib/resource_file.py
@@ -57,6 +57,44 @@ class ResourceFile():
         """
         self.zip_file_name = zip_file_name
 
+    def count_lines(self, name):
+        """
+        Count the number of lines in the file and return the number. Empty lines are ignored.
+
+        :param name: the name of the file
+        :return: the number of lines in the file. 0 is returned if the file doesn't exist
+        """
+        name = self.clean_name(name)
+
+        # ensure all data has been flushed from the writer for this file before we attempt to count
+        if name in self.writers and not self.writers[name].closed:
+            self.writers[name].flush()
+
+        full_path = os.path.join(self.working_folder, name)
+        if os.path.exists(full_path):
+            with open(full_path, 'r') as f:
+                # count the number of lines, ignoring the blank ones
+                return len([line for line in f.readlines() if line.strip()])
+        return 0
+
+    def delete(self, name):
+        """
+        Deletes the file with the given name and closes the writer for it (if there is one).
+
+        :param name: the name of the file
+        """
+        name = self.clean_name(name)
+
+        # ensure all data has been flushed from the writer for this file and close it
+        if name in self.writers and not self.writers[name].closed:
+            self.writers[name].flush()
+            self.writers[name].close()
+
+        full_path = os.path.join(self.working_folder, name)
+        # if the file exists, remove it
+        if os.path.exists(full_path):
+            os.remove(full_path)
+
     def get_delimiter(self):
         mapping = {
             'csv': ',',

--- a/ckanpackager/tasks/dwc_archive_package_task.py
+++ b/ckanpackager/tasks/dwc_archive_package_task.py
@@ -136,6 +136,15 @@ class DwcArchivePackageTask(DatastorePackageTask):
         if 'eml' in self.request_params:
             x_meta.attrib['metadata'] = 'eml.xml'
         for extension in archive.extensions():
+            filename = archive.file_name(extension)
+            # only include the extension xml in the meta file if the file has contents
+            line_count = resource.count_lines(filename)
+            # no lines or just the header means the file is empty
+            if line_count == 0 or line_count == 1:
+                # delete it and then skip modifying the xml
+                resource.delete(filename)
+                continue
+
             if self._dwc_core_terms.is_core_extension(extension):
                 x_section = etree.SubElement(x_meta, 'core')
             else:
@@ -153,7 +162,7 @@ class DwcArchivePackageTask(DatastorePackageTask):
             x_section.attrib['rowType'] = terms.row_type(extension)
             x_files = etree.SubElement(x_section, 'files')
             x_location = etree.SubElement(x_files, 'location')
-            x_location.text = archive.file_name(extension)
+            x_location.text = filename
             if self._dwc_core_terms.is_core_extension(extension):
                 x_id = etree.SubElement(x_section, 'id')
             else:


### PR DESCRIPTION
If a file is empty it shouldn't be included in the DwC-A nor the metadata.

Closes https://github.com/NaturalHistoryMuseum/ckanpackager/issues/36