### PR TITLE
Add a timeout to the URL fetching

### DIFF
--- a/ckanpackager/tasks/url_package_task.py
+++ b/ckanpackager/tasks/url_package_task.py
@@ -30,7 +30,8 @@ class UrlPackageTask(PackageTask):
         """
         try:
             output_stream = resource.get_writer()
-            input_stream = urllib2.urlopen(self.request_params['resource_url'])
+            # use a 30 second timeout to stop us hanging forever if the url is unresponsive
+            input_stream = urllib2.urlopen(self.request_params['resource_url'], timeout=30)
             self.log.info("Fetching and saving file.")
             shutil.copyfileobj(input_stream, output_stream)
             resource.create_zip(self.config['ZIP_COMMAND'])


### PR DESCRIPTION
This prevents us from waiting forever for a response if no response is coming.

The timeout has been set at 30 seconds for now. Note that this is a timeout between bytes received as detailed here: https://stackoverflow.com/questions/9548869/read-timeout-using-either-urllib2-or-any-other-http-library/32684677#32684677 so this will have no impact on large URL content downloads that take over 30 seconds to complete.

Closes https://github.com/NaturalHistoryMuseum/ckanpackager/issues/41