### PR TITLE
Allow optional email address anonymization

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,16 @@ SECRET = '8ba6d280d4ce9a416e9b604f3f0ebb'
 # This is opened multiple times, so you can not use sqlite:///:memory:
 STATS_DB = 'sqlite:////var/lib/ckanpackager/stats.db'
 
+# if enabled, email addresses are hashed before storage so that their identities remain anonymous
+# but they are still uniquely identifiable. This affects the `requests` and `errors` tables
+# respecively, where the hashed email is stored in the `email` column. In the `requests` table an
+# additional column will be created if this setting is turned on, specifically the `domain` column
+# which holds the domain part of the email address to allow grouping of the data by source
+# institution for example. When switching this setting from False (or non-existant) to True it is
+# necessary to run the anonymize migration script first whilst the server is offline, see
+# anonymze.py.
+ANONYMIZE_EMAILS = False
+
 # Celery (message queue) broker. See http://celery.readthedocs.org/en/latest/getting-started/first-steps-with-celery.html#choosing-a-broker
 # Defaults to 'redis://localhost:6379/0' . To test this (but not for production)
 # you can use sqlite with 'sqla+sqlite:////tmp/celery.db'

--- a/ckanpackager/anonymize.py
+++ b/ckanpackager/anonymize.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+"""
+This script contains a command line program which anonymizes an existing database of non-anonymized
+data. It should only be run once when changing the `ANONYMIZE_EMAILS` setting from False (or
+non-existant) to True. Running it multiple times will cause problems and would be impossible to
+unpick due to the one way hashing of the email addresses (the whole point really!).
+
+To run, simply run this script from the ckanpackager's virtualenv or indeed whatever python env it
+is installed into:
+
+    `python anonymize.py --help`
+
+See help information for details of parameters.
+"""
+
+import argparse
+
+import dataset
+
+from ckanpackager.lib.statistics import anonymize_email, extract_domain
+
+
+class Anonymizer(object):
+    """
+    Class for anonymizing existing data in the ckanpackager's stats database. This should be only be
+    run if the `ANONYMIZE_EMAILS` config flag has been set to True after data has been inserted into
+    a database whilst it was False (or indeed not present at all).
+    """
+
+    def __init__(self, database_url, dry_run):
+        """
+        :param database_url: the database url for the dataset lib, this should be in an sqlalchemy
+                             compatible form
+        :param dry_run: if True no modifications are made to the database and what would have been
+                        done is logged
+        """
+        self.database = dataset.connect(database_url)
+        self.dry_run = dry_run
+        # cache the hashes of the email addresses we cache to avoid wasting time repeating work
+        # we've already done
+        self.hash_cache = {}
+
+    def get_hashed_email(self, email):
+        """
+        Given an email address, hash it and return the hash. This will use the hash cache if it can.
+
+        :param email: the email address
+        :return: the hashed email address
+        """
+        if email not in self.hash_cache:
+            self.hash_cache[email] = anonymize_email(email)
+        return self.hash_cache[email]
+
+    def get_requests_rows(self):
+        """
+        Returns a list of dicts which represent updates to be applied to each row of the requests
+        table. The update includes the domain and the hashed email address from the original row as
+        well as the id of the row so that it is known which row is meant to be updated with the
+        data.
+
+        :return: a list of row dicts ready for dataset's update function
+        """
+        rows = []
+        for row in self.database[u'requests'].all():
+            # make sure we are working with the lowercase email address to avoid duplication due to
+            # different case
+            email = row[u'email'].lower()
+            domain = extract_domain(email)
+            hashed_email = self.get_hashed_email(email)
+            row = {
+                u'id': row[u'id'],
+                u'email': hashed_email,
+                u'domain': domain
+            }
+            rows.append(row)
+        return rows
+
+    def get_errors_rows(self):
+        """
+        Returns a list of dicts which represent updates to be applied to each row of the errors
+        table. The update includes the hashed email address from the original row as well as the id
+        of the row so that it is known which row is meant to be updated with the data.
+
+        :return: a list of row dicts ready for dataset's update function
+        """
+        rows = []
+        for row in self.database[u'errors'].all():
+            # make sure we are working with the lowercase email address to avoid duplication due to
+            # different case
+            email = row[u'email'].lower()
+            hashed_email = self.get_hashed_email(email)
+            row = {
+                u'id': row[u'id'],
+                u'email': hashed_email
+            }
+            rows.append(row)
+        return rows
+
+    def run(self):
+        """
+        Iterate over the rows in the requests and errors tables, replacing email addresses with
+        hashed versions. The requests table will also have a new column added to store the domain
+        from the email address to allow us to produce statistics based on the domains of requesters.
+        """
+        updates = {
+            u'requests': self.get_requests_rows(),
+            u'errors': self.get_errors_rows(),
+        }
+        for table, rows in updates.items():
+            for row in rows:
+                if self.dry_run:
+                    print u'Would have updated {} with {}'.format(table, row)
+                else:
+                    self.database[table].update(row, [u'id'])
+
+
+if __name__ == u'__main__':
+    description = u'''Anonymize the data in the ckanpackager database.
+                      This is a one way process and cannot be undone so be careful! This script
+                      should only be run once, when changing the `ANONYMIZE_EMAILS` setting from
+                      False (or non-existant) to True. Take care!'''
+    database_url_help = u'''an sqlalchemy compatible database url for the ckanpackager's stats
+                            database to to be anonymized'''
+    dry_run_help = u'''Don't run the anonymization, just log about what would be done'''
+
+    parser = argparse.ArgumentParser(description=description)
+    # we could get this from the config but then we'd have to import it correctly or fire up a whole
+    # flask app just to get to it. It makes more sense to just ask the user to pass it, particularly
+    # given this command should only need to be run once upon changing the `ANONYMIZE_EMAILS`
+    # setting
+    parser.add_argument(u'database_url', type=unicode, help=database_url_help)
+    parser.add_argument(u'--dry_run', u'-d', action=u'store_true', help=dry_run_help)
+
+    args = parser.parse_args()
+
+    anonymizer = Anonymizer(**vars(args))
+    anonymizer.run()

--- a/ckanpackager/config_defaults.py
+++ b/ckanpackager/config_defaults.py
@@ -3,6 +3,7 @@ HOST = '127.0.0.1'
 PORT = 8765
 SECRET = '8ba6d280d4ce9a416e9b604f3f0ebb'
 STATS_DB = 'sqlite:////var/lib/ckanpackager/stats.db'
+ANONYMIZE_EMAILS = False
 CELERY_BROKER = 'redis://localhost:6379/0'
 PAGE_SIZE = 5000
 SLOW_REQUEST = 50000

--- a/ckanpackager/controllers/status.py
+++ b/ckanpackager/controllers/status.py
@@ -1,8 +1,9 @@
-from flask import request, Blueprint, current_app, g
+from flask import request, Blueprint, current_app
 from flask.json import jsonify
+
 from ckanpackager import logic
-from ckanpackager.lib.utils import BadRequestError
 from ckanpackager.lib.statistics import statistics
+from ckanpackager.lib.utils import BadRequestError
 
 status = Blueprint('status', __name__)
 
@@ -20,15 +21,17 @@ def ckanpackager_status():
 @status.route('/statistics/<stype>', methods=['POST'])
 def application_statistics(stype=None):
     logic.authorize_request(request.form)
+
+    # create a stats object for database access
+    stats = statistics(current_app.config['STATS_DB'], current_app.config.get(u'ANONYMIZE_EMAILS'))
+
     if stype is None:
         conditions = {}
         if 'resource_id' in request.form:
             conditions['resource_id'] = request.form.get('resource_id')
         return jsonify(
             status=True,
-            totals=statistics(current_app.config['STATS_DB']).get_totals(
-                **conditions
-            )
+            totals=stats.get_totals(**conditions)
         )
     elif stype in ['requests', 'errors']:
         start = int(request.form.get('offset', 0))
@@ -41,16 +44,12 @@ def application_statistics(stype=None):
         if stype == 'requests':
             return jsonify(
                 success=True,
-                requests=statistics(current_app.config['STATS_DB']).get_requests(
-                    start, count, **conditions
-                )
+                requests=stats.get_requests(start, count, **conditions)
             )
         else:
             return jsonify(
                 success=True,
-                errors=statistics(current_app.config['STATS_DB']).get_errors(
-                    start, count, **conditions
-                )
+                errors=stats.get_errors(start, count, **conditions)
             )
     else:
         raise BadRequestError('Unknown statistics request {}'.format(stype))

--- a/ckanpackager/lib/statistics.py
+++ b/ckanpackager/lib/statistics.py
@@ -136,61 +136,61 @@ class CkanPackagerStatistics(object):
             'message': message
         })
 
-    def get_requests(self, start=0, count=100, **kargs):
+    def get_requests(self, start=0, count=100, **kwargs):
         """Return requests as a list of dictionaries
 
         @param start: start of the query
         @param count: Number of requests to return
-        @param **kargs: conditions
+        @param **kwargs: conditions
         @returns: List of rows (as dictionaries)
         """
         if self.anonymize:
-            anonymize_kwargs(kargs)
+            anonymize_kwargs(kwargs)
 
         result = []
         iterator = self._db['requests'].find(
             _offset=start,
             _limit=count,
             order_by='-timestamp',
-            **kargs
+            **kwargs
         )
         for row in iterator:
             del row['id']
             result.append(row)
         return result
 
-    def get_errors(self, start=0, count=100, **kargs):
+    def get_errors(self, start=0, count=100, **kwargs):
         """Return errors as a list of dicts
 
         @param start: start of the query
         @param count: number of requests to return
-        @param **kargs: conditions
+        @param **kwargs: conditions
         @returns: List of rows (as dictionaries)
         """
         if self.anonymize:
-            anonymize_kwargs(kargs)
+            anonymize_kwargs(kwargs)
 
         result = []
         iterator = self._db['errors'].find(
             _offset=start,
             _limit=count,
             order_by='-timestamp',
-            **kargs
+            **kwargs
         )
         for row in iterator:
             del row['id']
             result.append(row)
         return result
 
-    def get_totals(self, **kargs):
+    def get_totals(self, **kwargs):
         """Return the overall stastitics (the totals)
 
-        @param **kargs: conditions on the totals table
+        @param **kwargs: conditions on the totals table
         @returns: Dictionary of rows (as dictionaries), indexed by the resource
                   id.
         """
         totals = {}
-        for row in self._db['totals'].find(**kargs):
+        for row in self._db['totals'].find(**kwargs):
             totals[row['resource_id']] = {
                 'emails': row['emails'],
                 'errors': row['errors'],
@@ -198,13 +198,13 @@ class CkanPackagerStatistics(object):
             }
         return totals
  
-    def _increase_totals(self, counter, **kargs):
+    def _increase_totals(self, counter, **kwargs):
         """Increase the given counter
        
         @param counter: Name of the counter
-        @param **kargs: conditions
+        @param **kwargs: conditions
         """
-        r = self._db['totals'].find_one(**kargs)
+        r = self._db['totals'].find_one(**kwargs)
         if r is None:
             r = {
                 'resource_id': '*',
@@ -212,7 +212,7 @@ class CkanPackagerStatistics(object):
                 'requests': 0,
                 'emails': 0
             }
-            for key in kargs:
-                r[key] = kargs[key]
+            for key in kwargs:
+                r[key] = kwargs[key]
         r[counter] += 1
-        self._db['totals'].upsert(r, kargs.keys())
+        self._db['totals'].upsert(r, kwargs.keys())

--- a/ckanpackager/lib/statistics.py
+++ b/ckanpackager/lib/statistics.py
@@ -3,7 +3,6 @@ import time
 
 import bcrypt
 import dataset
-from flask import current_app
 
 
 def extract_domain(email_address):
@@ -57,27 +56,31 @@ def anonymize_kwargs(kwargs):
         kwargs['email'] = anonymize_email(kwargs['email'])
 
 
-def statistics(database_url):
+def statistics(database_url, anonymize):
     """Create a new CkanPackagerStatistics object and return it.
 
     This is useful for one-liners: statistics(db).log_request(request)
 
     @param database_url: database url as per
            http://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls
+    @param anonymize: boolean indicating whether the email addresses in the database should be
+                      treated anonymously
     """
-    return CkanPackagerStatistics(database_url)
+    return CkanPackagerStatistics(database_url, anonymize)
 
 
 class CkanPackagerStatistics(object):
 
-    def __init__(self, database_url):
+    def __init__(self, database_url, anonymize):
         """Class used to track application statistics.
 
         @param database_url: database url as per 
                http://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls
+        @param anonymize: boolean indicating whether the email addresses in the database should be
+                          treated anonymously
         """
         self._db = dataset.connect(database_url)
-        self.anonymize = current_app.config.get(u'ANONYMIZE_EMAILS', False)
+        self.anonymize = anonymize
 
     def log_request(self, resource_id, email, count=None):
         """Log a new incoming request to the statistics

--- a/ckanpackager/lib/statistics.py
+++ b/ckanpackager/lib/statistics.py
@@ -1,5 +1,60 @@
+import base64
 import time
+
+import bcrypt
 import dataset
+from flask import current_app
+
+
+def extract_domain(email_address):
+    """
+    Given an email address, extract the domain name from it. This is done by finding the @ and
+    then splicing the email address and returning everything found after the @. If no @ is found
+    then the entire email address string is returned.
+
+    :param email_address:
+    :return:
+    """
+    email_address = email_address.lower()
+    # figure out the domain from the email address
+    try:
+        return email_address[email_address.index(u'@') + 1:]
+    except ValueError:
+        # no @ found, just use the whole string
+        return email_address
+
+
+def anonymize_email(email_address, domain=None):
+    """
+    Hash the email address securely and return it as a string. We use bcrypt to do this and use the
+    domain as the salt.
+
+    :param email_address: the hashed email address
+    """
+    email_address = email_address.lower()
+    if domain is None:
+        domain = extract_domain(email_address)
+    # create a custom salt by base64 encoding the domain and then trimming the whole thing to 22
+    # characters (which is bcrypt's required salt length). Note that we fill the right side of the
+    # domain with dots to ensure it's at least 18 characters in length. This is necessary as we need
+    # to ensure that the base64 encode result is at least 22 characters long and 18 is the minimum
+    # input length necessary to create a base64 encoding result of at least 22 characters.
+    salt = u'$2b$12$' + base64.b64encode(domain.zfill(18))[:22]
+    return bcrypt.hashpw(email_address.encode(u'utf-8'), salt.encode(u'utf-8'))
+
+
+def anonymize_kwargs(kwargs):
+    """
+    Given a dict of kwargs, replace the value associated with the email key (if there is one)
+    with the anonymized version of the email address. Does nothing if anonymization is turned
+    off or if email isn't a key in the dict. Any changes are made in place.
+
+    :param kwargs: a dict
+    """
+    # note that we use get instead of in on the kwargs as we want to only anonymize the email
+    # address if it exists in the kwargs and isn't None
+    if kwargs.get('email', None) is not None:
+        kwargs['email'] = anonymize_email(kwargs['email'])
 
 
 def statistics(database_url):
@@ -14,6 +69,7 @@ def statistics(database_url):
 
 
 class CkanPackagerStatistics(object):
+
     def __init__(self, database_url):
         """Class used to track application statistics.
 
@@ -21,6 +77,7 @@ class CkanPackagerStatistics(object):
                http://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls
         """
         self._db = dataset.connect(database_url)
+        self.anonymize = current_app.config.get(u'ANONYMIZE_EMAILS', False)
 
     def log_request(self, resource_id, email, count=None):
         """Log a new incoming request to the statistics
@@ -28,27 +85,34 @@ class CkanPackagerStatistics(object):
         @param resource_id: The resource id that was requested
         @param email: The email address that requested the resource
         """
-        # Increase totals
+        domain = extract_domain(email)
+        if self.anonymize:
+            email = anonymize_email(email, domain)
+
+        # increase totals for all resources and the resource requested
         self._increase_totals('requests', resource_id='*')
+        self._increase_totals('requests', resource_id=resource_id)
+
+        # if there isn't already a request in the requests table from the email address we need to
+        # increment the unique requesters count on all resources (*)
         if self._db['requests'].find_one(email=email) is None:
             self._increase_totals('emails', resource_id='*')
-        # Increase totals for that resource
-        self._increase_totals('requests', resource_id=resource_id)
-        resource_match = self._db['requests'].find_one(
-            email=email,
-            resource_id=resource_id
-        )
+
+        # increase totals for that resource if the email address hasn't requested this resource
+        # before
+        resource_match = self._db['requests'].find_one(email=email, resource_id=resource_id)
         if resource_match is None:
             self._increase_totals('emails', resource_id=resource_id)
 
-        # Store timestamped request 
+        # store request
         self._db['requests'].insert({
-            'timestamp': int(time.time()),
-            'resource_id': resource_id,
-            'email': email,
-            'count': count
+            u'count': count,
+            u'domain': domain,
+            u'email': email,
+            u'resource_id': resource_id,
+            u'timestamp': int(time.time()),
         })
-            
+
     def log_error(self, resource_id, email, message):
         """Log a new error to the statistics
 
@@ -57,6 +121,9 @@ class CkanPackagerStatistics(object):
         @param email: The email address that requested the resource
         @param message: The error message
         """
+        if self.anonymize:
+            email = anonymize_email(email)
+
         # Increase totals
         self._increase_totals('errors', resource_id='*')
         # Increase totals for that resource
@@ -77,6 +144,9 @@ class CkanPackagerStatistics(object):
         @param **kargs: conditions
         @returns: List of rows (as dictionaries)
         """
+        if self.anonymize:
+            anonymize_kwargs(kargs)
+
         result = []
         iterator = self._db['requests'].find(
             _offset=start,
@@ -97,6 +167,9 @@ class CkanPackagerStatistics(object):
         @param **kargs: conditions
         @returns: List of rows (as dictionaries)
         """
+        if self.anonymize:
+            anonymize_kwargs(kargs)
+
         result = []
         iterator = self._db['errors'].find(
             _offset=start,

--- a/ckanpackager/tasks/package_task.py
+++ b/ckanpackager/tasks/package_task.py
@@ -77,19 +77,21 @@ class PackageTask(object):
 
     def run(self, logger=None):
         """Run the task."""
+        # create a stats object for database access
+        stats = statistics(self.config['STATS_DB'], self.config.get(u'ANONYMIZE_EMAILS'))
         try:
             if logger is not None:
                 self.log = logger
             else:
                 self.log = logging.getLogger(__name__)
             self._run()
-            statistics(self.config['STATS_DB']).log_request(
+            stats.log_request(
                 self.request_params['resource_id'],
                 self.request_params['email'],
                 self.request_params.get('limit', None)
             )
         except Exception as e:
-            statistics(self.config['STATS_DB']).log_error(
+            stats.log_error(
                 self.request_params['resource_id'],
                 self.request_params['email'],
                 traceback.format_exc()

--- a/ckanpackager/tests/test_anonymize.py
+++ b/ckanpackager/tests/test_anonymize.py
@@ -1,0 +1,131 @@
+from mock import MagicMock
+from nose.tools import assert_equals, assert_not_equals, assert_in
+
+from ckanpackager.anonymize import Anonymizer
+
+
+class TestAnonymizer(object):
+
+    def test_hashed_email(self):
+        anonymizer = Anonymizer(u'sqlite:///:memory:', True)
+
+        # check it uses the cache
+        anonymizer.hash_cache = {u'test@e.com': u'hashed!'}
+        assert_equals(anonymizer.get_hashed_email(u'test@e.com'), u'hashed!')
+
+        # check it updates the cache when a new email is hashed
+        anonymizer.hash_cache = {u'test@e.com': u'hashed!'}
+        hashed_email = anonymizer.get_hashed_email(u'test2@e.com')
+        assert_not_equals(hashed_email, u'hashed!')
+        assert_in(u'test2@e.com', anonymizer.hash_cache)
+        assert_equals(anonymizer.hash_cache[u'test2@e.com'], hashed_email)
+
+    def test_get_requests_rows(self):
+        anonymizer = Anonymizer(u'sqlite:///:memory:', True)
+
+        # mock the rows in the database
+        mock_rows = [
+            {u'id': 1, u'email': u'one@e.com'},
+            {u'id': 2, u'email': u'two@e.com'},
+            {u'id': 3, u'email': u'three@e.com'},
+            # put a row in with capital letters to test they are lowered
+            {u'id': 4, u'email': u'TWO@E.com'},
+        ]
+        anonymizer.database = MagicMock()
+        anonymizer.database[u'requests'].all = MagicMock(return_value=mock_rows)
+
+        # setup the cache the way we want it
+        anonymizer.hash_cache = {
+            u'one@e.com': u'hash1',
+            u'two@e.com': u'hash2',
+            u'three@e.com': u'hash3',
+        }
+
+        rows = anonymizer.get_requests_rows()
+        assert_equals(rows[0], {u'id': 1, u'email': u'hash1', u'domain': u'e.com'})
+        assert_equals(rows[1], {u'id': 2, u'email': u'hash2', u'domain': u'e.com'})
+        assert_equals(rows[2], {u'id': 3, u'email': u'hash3', u'domain': u'e.com'})
+        assert_equals(rows[3], {u'id': 4, u'email': u'hash2', u'domain': u'e.com'})
+
+    def test_get_errors_rows(self):
+        anonymizer = Anonymizer(u'sqlite:///:memory:', True)
+
+        # mock the rows in the database
+        mock_rows = [
+            {u'id': 1, u'email': u'one@e.com'},
+            {u'id': 2, u'email': u'two@e.com'},
+            {u'id': 3, u'email': u'three@e.com'},
+            # put a row in with capital letters to test they are lowered
+            {u'id': 4, u'email': u'TWO@e.com'},
+        ]
+        anonymizer.database = MagicMock()
+        anonymizer.database[u'errors'].all = MagicMock(return_value=mock_rows)
+
+        # setup the cache the way we want it
+        anonymizer.hash_cache = {
+            u'one@e.com': u'hash1',
+            u'two@e.com': u'hash2',
+            u'three@e.com': u'hash3',
+        }
+
+        rows = anonymizer.get_errors_rows()
+        assert_equals(rows[0], {u'id': 1, u'email': u'hash1'})
+        assert_equals(rows[1], {u'id': 2, u'email': u'hash2'})
+        assert_equals(rows[2], {u'id': 3, u'email': u'hash3'})
+        assert_equals(rows[3], {u'id': 4, u'email': u'hash2'})
+
+    def test_run_dry(self):
+        anonymizer = Anonymizer(u'sqlite:///:memory:', True)
+
+        anonymizer.database = MagicMock()
+        anonymizer.get_requests_rows = MagicMock(return_value=[1, 2, 3, 4, 5, 6])
+        anonymizer.get_errors_rows = MagicMock(return_value=[7, 8, 9, 10])
+
+        anonymizer.run()
+
+        assert_equals(anonymizer.database.call_count, 0)
+
+    def test_run(self):
+        anonymizer = Anonymizer(u'sqlite:///:memory:', False)
+
+        # add some data to the database
+        anonymizer.database[u'requests'].insert({
+            u'count': 432,
+            u'email': u'someone@test.com',
+            u'resource_id': u'some-resource-id',
+            u'timestamp': 12,
+        })
+        anonymizer.database[u'errors'].insert({
+            u'message': u'something went horribly wrong :(',
+            u'email': u'someone@test.com',
+            u'resource_id': u'some-resource-id',
+            u'timestamp': 12,
+        })
+        # setup the hash cache the way we want it
+        anonymizer.hash_cache = {u'someone@test.com': u'hash!'}
+
+        # run the anonymizer
+        anonymizer.run()
+
+        # check the requests have all be modified
+        requests = list(anonymizer.database[u'requests'].all())
+        assert_equals(len(requests), 1)
+        assert_equals(requests[0], {
+            u'id': 1,
+            u'count': 432,
+            u'email': u'hash!',
+            u'resource_id': u'some-resource-id',
+            u'timestamp': 12,
+            u'domain': u'test.com',
+        })
+
+        # check the errors have all been modified
+        errors = list(anonymizer.database[u'errors'].all())
+        assert_equals(len(errors), 1)
+        assert_equals(errors[0], {
+            u'id': 1,
+            u'email': u'hash!',
+            u'resource_id': u'some-resource-id',
+            u'timestamp': 12,
+            u'message': u'something went horribly wrong :(',
+        })

--- a/ckanpackager/tests/test_package_task.py
+++ b/ckanpackager/tests/test_package_task.py
@@ -51,6 +51,7 @@ class TestPackageTask(object):
             'STORE_DIRECTORY': tempfile.mkdtemp(),
             'TEMP_DIRECTORY': tempfile.mkdtemp(),
             'STATS_DB': 'sqlite:///' + os.path.join(self._temp_db_folder, 'db'),
+            'ANONYMIZE_EMAILS': False,
             'CACHE_TIME': 60*60*24,
             'EMAIL_FROM': '{resource_id}-{zip_file_name}-{ckan_host}-from',
             'EMAIL_BODY': '{resource_id};{zip_file_name};{ckan_host} body',
@@ -197,7 +198,7 @@ class TestPackageTask(object):
             'carrot': 'cake'
         }, self._config)
         t.run()
-        stats = CkanPackagerStatistics(self._config['STATS_DB'])
+        stats = CkanPackagerStatistics(self._config['STATS_DB'], self._config['ANONYMIZE_EMAILS'])
         requests = stats.get_requests()
         assert_equals(1, len(requests))
         assert_equals('the-resource-id', requests[0]['resource_id'])
@@ -212,7 +213,7 @@ class TestPackageTask(object):
         }, self._config)
         with assert_raises(Exception) as context:
             t.run()
-        stats = CkanPackagerStatistics(self._config['STATS_DB'])
+        stats = CkanPackagerStatistics(self._config['STATS_DB'], self._config['ANONYMIZE_EMAILS'])
         errors = stats.get_errors()
         assert_equals(1, len(errors))
         assert_equals('the-resource-id', errors[0]['resource_id'])

--- a/ckanpackager/tests/test_statistics.py
+++ b/ckanpackager/tests/test_statistics.py
@@ -1,6 +1,10 @@
 import time
-from nose.tools import assert_equals, assert_true, assert_not_in, assert_in
-from ckanpackager.lib.statistics import CkanPackagerStatistics, statistics
+
+from mock import patch
+from nose.tools import assert_equals, assert_true, assert_not_in, assert_in, assert_not_equals
+from ckanpackager.lib.statistics import CkanPackagerStatistics, statistics, extract_domain, \
+    anonymize_email, anonymize_kwargs
+
 
 class TestStatistics(object):
     def setUp(self):
@@ -28,6 +32,7 @@ class TestStatistics(object):
         assert_equals(1, len(requests))
         assert_equals('abcd', requests[0]['resource_id'])
         assert_equals('someone@example.com', requests[0]['email'])
+        assert_equals('example.com', requests[0]['domain'])
         assert_equals(type(requests[0]['timestamp']), int)
         # For the stats, an hour precision is enough - and this test
         # is unlikely to take more time so this test should be good.
@@ -181,3 +186,245 @@ class TestStatistics(object):
         """Check that the 'statistics' shortcut returns an object as expected"""
         o = statistics('sqlite:///:memory:', False)
         assert_equals(CkanPackagerStatistics, type(o))
+
+
+class TestStatisticsAnonymized(object):
+
+    def setUp(self):
+        """
+        Create a statistics object with anonymizing turned on.
+        """
+        self._d = CkanPackagerStatistics('sqlite:///:memory:', True)
+
+        self.someone_hash = anonymize_email(u'someone@example.com')
+
+    def test_log_request(self):
+        """
+        Test that requests are logged
+        """
+        assert_equals(0, len(self._d.get_requests()))
+        self._d.log_request('abcd', 'someone@example.com')
+        assert_equals(1, len(self._d.get_requests()))
+
+    def test_log_multiple_request(self):
+        """Test that multiple requests are logged"""
+        assert_equals(0, len(self._d.get_requests()))
+        self._d.log_request('abcd', 'someone@example.com')
+        self._d.log_request('abcd', 'someone@example.com')
+        self._d.log_request('abcd', 'someone@example.com')
+        assert_equals(3, len(self._d.get_requests()))
+
+    def test_request_fields(self):
+        """Ensure logged request fields contain expected data"""
+        self._d.log_request('abcd', 'someone@example.com')
+        requests = self._d.get_requests()
+        assert_equals(1, len(requests))
+        assert_equals('abcd', requests[0]['resource_id'])
+        assert_equals(self.someone_hash, requests[0]['email'])
+        assert_equals('example.com', requests[0]['domain'])
+        assert_equals(type(requests[0]['timestamp']), int)
+        # For the stats, an hour precision is enough - and this test
+        # is unlikely to take more time so this test should be good.
+        assert_true(int(time.time()) - requests[0]['timestamp'] < 60*60)
+
+    def test_log_error(self):
+        """Test that errors are logged"""
+        assert_equals(0, len(self._d.get_errors()))
+        self._d.log_error('abcd', 'someone@example.com', 'it failed')
+        assert_equals(1, len(self._d.get_errors()))
+
+    def test_log_multiple_error(self):
+        """Test that multiple errors are logged"""
+        assert_equals(0, len(self._d.get_errors()))
+        self._d.log_error('abcd', 'someone@example.com', 'it failed')
+        self._d.log_error('abcd', 'someone@example.com', 'it failed')
+        self._d.log_error('abcd', 'someone@example.com', 'it failed')
+        assert_equals(3, len(self._d.get_errors()))
+
+    def test_error_fields(self):
+        """Test that logged error fields contain expected data"""
+        self._d.log_error('abcd', 'someone@example.com', 'it failed')
+        errors = self._d.get_errors()
+        assert_equals(1, len(errors))
+        assert_equals('abcd', errors[0]['resource_id'])
+        assert_equals(self.someone_hash, errors[0]['email'])
+        assert_equals('it failed', errors[0]['message'])
+        assert_equals(type(errors[0]['timestamp']), int)
+        # For the stats, an hour precision is enough - and this test
+        # is unlikely to take more time so this test should be good.
+        assert_true(int(time.time()) - errors[0]['timestamp'] < 60*60)
+
+    def test_overall_request_totals_updated(self):
+        """Test that the overall request totals are updated"""
+        self._d.log_request('abcd', 'someone1@example.com')
+        self._d.log_request('abcd', 'someone1@example.com')
+        self._d.log_request('efgh', 'someone2@example.com')
+        totals = self._d.get_totals()
+        assert_equals(3, totals['*']['requests'])
+
+    def test_overall_error_totals_updated(self):
+        """Test that the overall error totals are updated"""
+        self._d.log_error('abcd', 'someone1@example.com', 'it failed')
+        self._d.log_error('abcd', 'someone1@example.com', 'it failed')
+        self._d.log_error('abcd', 'someone2@example.com', 'it failed')
+        self._d.log_error('efgh', 'someone3@example.com', 'it failed')
+        totals = self._d.get_totals()
+        assert_equals(4, totals['*']['errors'])
+
+    def test_per_resource_request_totals_updated(self):
+        """Test that per-resource request totals are updated"""
+        self._d.log_request('abcd', 'someone1@example.com')
+        self._d.log_request('abcd', 'someone1@example.com')
+        self._d.log_request('efgh', 'someone2@example.com')
+        totals = self._d.get_totals()
+        assert_equals(2, totals['abcd']['requests'])
+
+    def test_per_resource_error_totals_updated(self):
+        """Test that the per-resource error totals are updated"""
+        self._d.log_error('abcd', 'someone1@example.com', 'it failed')
+        self._d.log_error('abcd', 'someone1@example.com', 'it failed')
+        self._d.log_error('abcd', 'someone2@example.com', 'it failed')
+        self._d.log_error('efgh', 'someone3@example.com', 'it failed')
+        totals = self._d.get_totals()
+        assert_equals(3, totals['abcd']['errors'])
+
+    def test_overall_unique_emails_updated(self):
+        """Test that the overall number of unique emails are updated"""
+        self._d.log_request('abcd', 'someone1@example.com')
+        self._d.log_request('abcd', 'someone1@example.com')
+        self._d.log_request('efgh', 'someone2@example.com')
+        totals = self._d.get_totals()
+        assert_equals(2, totals['*']['emails'])
+
+    def test_per_resource_unique_emails_updated(self):
+        """Test that the per-resource number of unique emails are updated"""
+        self._d.log_request('abcd', 'someone1@example.com')
+        self._d.log_request('abcd', 'someone1@example.com')
+        self._d.log_request('abcd', 'someone2@example.com')
+        self._d.log_request('efgh', 'someone3@example.com')
+        totals = self._d.get_totals()
+        assert_equals(2, totals['abcd']['emails'])
+
+    def test_totals_dont_include_id(self):
+        """Check that the totals returned don't include an id field"""
+        self._d.log_request('abcd', 'someone1@example.com')
+        totals = self._d.get_totals()
+        assert_not_in('id', totals['*'])
+        assert_not_in('resource_id', totals['*'])
+        assert_not_in('id', totals['abcd'])
+        assert_not_in('resource_id', totals['abcd'])
+
+    def test_totals_return_all_resources(self):
+        """Check that, unfilterd, get_totals returns entries for all resources"""
+        self._d.log_request('abcd', 'someone1@example.com')
+        self._d.log_request('abcd', 'someone1@example.com')
+        self._d.log_request('efgh', 'someone3@example.com')
+        self._d.log_request('ijkl', 'someone3@example.com')
+        totals = self._d.get_totals()
+        assert_in('*', totals)
+        assert_in('abcd', totals)
+        assert_in('efgh', totals)
+        assert_in('ijkl', totals)
+
+    def test_totals_filters(self):
+        """Check it's possible to filter the rows returned by get_totals"""
+        self._d.log_request('abcd', 'someone1@example.com')
+        self._d.log_request('abcd', 'someone1@example.com')
+        self._d.log_request('abcd', 'someone2@example.com')
+        self._d.log_request('efgh', 'someone3@example.com')
+        totals = self._d.get_totals(resource_id='abcd')
+        assert_not_in('*', totals)
+        assert_not_in('efgh', totals)
+        assert_in('abcd', totals)
+
+    def test_requests_dont_include_id(self):
+        """Check that the requests returned don't include an id field"""
+        self._d.log_request('abcd', 'someone1@example.com')
+        requests = self._d.get_requests()
+        assert_not_in('id', requests[0])
+
+    def test_errors_dont_include_id(self):
+        """Check that the errors returned don't include an id field"""
+        self._d.log_error('abcd', 'someone1@example.com', 'borken')
+        errors = self._d.get_errors()
+        assert_not_in('id', errors[0])
+
+    def test_requests_ordered_by_timestamp_desc(self):
+        """Check that the returned requests are ordered by timestamp desc"""
+        self._d.log_request('abcd', 'someone1@example.com')
+        time.sleep(1)
+        self._d.log_request('abcd', 'someone1@example.com')
+        time.sleep(1)
+        self._d.log_request('abcd', 'someone2@example.com')
+        requests = self._d.get_requests()
+        assert_true(requests[0]['timestamp'] > requests[1]['timestamp'])
+        assert_true(requests[1]['timestamp'] > requests[2]['timestamp'])
+
+    def test_errors_ordered_by_timestamp_desc(self):
+        """Check that the returned requests are ordered by timestamp desc"""
+        self._d.log_error('abcd', 'someone1@example.com', 'borken')
+        time.sleep(1)
+        self._d.log_error('abcd', 'someone1@example.com', 'borken')
+        time.sleep(1)
+        self._d.log_error('abcd', 'someone2@example.com', 'borken')
+        errors = self._d.get_errors()
+        assert_true(errors[0]['timestamp'] > errors[1]['timestamp'])
+        assert_true(errors[1]['timestamp'] > errors[2]['timestamp'])
+
+    def test_statistics_shortcut(self):
+        """Check that the 'statistics' shortcut returns an object as expected"""
+        o = statistics('sqlite:///:memory:', False)
+        assert_equals(CkanPackagerStatistics, type(o))
+
+
+def test_extract_domain():
+    assert_equals(extract_domain(u'someone@nhm.ac.uk'), u'nhm.ac.uk')
+    # if no @ is present, just return the whole thing
+    assert_equals(extract_domain(u'someone'), u'someone')
+    # if more than one @ is present, the "domain" starts at the first one
+    assert_equals(extract_domain(u'someone@@nhm.ac.uk'), u'@nhm.ac.uk')
+    # if only a @ is present, return empty
+    assert_equals(extract_domain(u'@'), u'')
+    # if the @ is at the end of the string, return empty
+    assert_equals(extract_domain(u'aaa@'), u'')
+
+
+def test_anonymize_email():
+    assert_equals(anonymize_email(u'someone@nhm.ac.uk'), anonymize_email(u'someone@nhm.ac.uk'))
+    assert_equals(anonymize_email(u'SOMEONE@nhm.ac.uk'), anonymize_email(u'someone@NHM.ac.uk'))
+    assert_not_equals(anonymize_email(u'someone@nhm.ac.uk'),
+                      anonymize_email(u'someone_else@nhm.ac.uk'))
+
+    # copes with an empty input
+    anonymize_email(u'')
+
+    # we know that the domain is used as the salt so lets check that silly salts don't throw errors
+
+    # much longer than the 22 character salt bcrypt needs
+    anonymize_email(u'a@{}'.format(u'x'*40))
+    # much shorter than the 22 character salt bcrypt needs
+    anonymize_email(u'a@{}'.format(u''))
+    anonymize_email(u'a@{}'.format(u'x'))
+
+
+@patch(u'ckanpackager.lib.statistics.anonymize_email')
+def test_anonymize_kwargs(mock_anonymize_email):
+    mock_hash = u'hashed!'
+    mock_anonymize_email.configure_mock(return_value=mock_hash)
+
+    kwargs = {u'email': u'someone@nhm.ac.uk'}
+    anonymize_kwargs(kwargs)
+    assert_equals(kwargs[u'email'], u'hashed!')
+
+    kwargs = {}
+    anonymize_kwargs(kwargs)
+    assert_equals(kwargs, {})
+
+    kwargs = {u'another': u'different_thing', u'email': u'someone@nhm.ac.uk'}
+    anonymize_kwargs(kwargs)
+    assert_equals(kwargs[u'email'], u'hashed!')
+    assert_equals(kwargs[u'another'], u'different_thing')
+
+    kwargs = {u'email': None}
+    anonymize_kwargs(kwargs)
+    assert_equals(kwargs[u'email'], None)

--- a/ckanpackager/tests/test_statistics.py
+++ b/ckanpackager/tests/test_statistics.py
@@ -5,7 +5,7 @@ from ckanpackager.lib.statistics import CkanPackagerStatistics, statistics
 class TestStatistics(object):
     def setUp(self):
         """Create a statistics object"""
-        self._d = CkanPackagerStatistics('sqlite:///:memory:')
+        self._d = CkanPackagerStatistics('sqlite:///:memory:', False)
 
     def test_log_request(self):
         """Test that requests are logged"""
@@ -179,5 +179,5 @@ class TestStatistics(object):
 
     def test_statistics_shortcut(self):
         """Check that the 'statistics' shortcut returns an object as expected"""
-        o = statistics('sqlite:///:memory:')
+        o = statistics('sqlite:///:memory:', False)
         assert_equals(CkanPackagerStatistics, type(o))

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ beautifulsoup4==4.2.1
 lxml==3.4.0
 urllib3==1.7.1
 raven==5.32.0
+bcrypt==3.1.4


### PR DESCRIPTION
This PR adds a new feature which allows email addresses to be anonymously stored in the stats database whilst remaining uniquely identifiable. To enable this feature:

- set the config setting `ANONYMIZE_EMAILS` to `True` (default is False to maintain backwards compatibility)
- run the `anonymize` script included in this PR to switch any existing database data to the new format (read the comments on this in the `anonymize.py` file to make sure you know what you're doing here - it's a one-way operation that can't be undone, _hint: make a backup of the database before running it_).
