### PR TITLE
Increase celery version to 3.1.25

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,10 +18,7 @@ MarkupSafe==0.23
 itsdangerous==0.24
 inflection==0.2.1
 flower==0.7.3
-celery==3.1.17
-pytz==2014.10
-billiard==3.3.0.19
-kombu==3.0.24
+celery==3.1.25
 anyjson==0.3.3
 amqp==1.4.6
 tornado==4.1


### PR DESCRIPTION
This is so that we can support python versions >= 2.7.11. Celery 2.7.20 contains the actual bump in version to kombu we need (kombu >= 3.3.30). This came about because they were using a private method from a builtin module: https://github.com/celery/kombu/issues/545. Celery 3.1.25 has this fix and is the highest 3.1.x version available so might as well go up to that.