### PR TITLE
Support XLSX downloads

### DIFF
--- a/ckanpackager/lib/resource_file.py
+++ b/ckanpackager/lib/resource_file.py
@@ -99,8 +99,11 @@ class ResourceFile():
         mapping = {
             'csv': ',',
             'tsv': '\t',
+            # if the format is xlsx then we're going to output a csv and then convert it after, so
+            # use a comma as the delimiter
+            'xlsx': ',',
         }
-        return mapping.get(self.request_params.get('format', 'csv'))
+        return mapping.get(self.format)
 
     def clean_name(self, name=None):
         """
@@ -125,8 +128,11 @@ class ResourceFile():
             mapping = {
                 'csv': '.csv',
                 'tsv': '.tsv',
+                # as with the get_delimiter function above, if we get an xlsx request we're going to
+                # output the data in csv format and then convert it later
+                'xlsx': '.csv',
             }
-            name = name[:-4] + mapping[self.request_params.get('format', 'csv')]
+            name = name[:-4] + mapping[self.format]
 
         return name
 

--- a/ckanpackager/lib/resource_file.py
+++ b/ckanpackager/lib/resource_file.py
@@ -200,7 +200,7 @@ class ResourceFile():
         for w in self.writers:
             if not self.writers[w].closed:
                 self.writers[w].close()
-        self.writers = []
+        self.writers.clear()
         # Remove the temp working folder
         if self.working_folder and os.path.exists(self.working_folder):
             shutil.rmtree(self.working_folder, True)

--- a/ckanpackager/tasks/datastore_package_task.py
+++ b/ckanpackager/tasks/datastore_package_task.py
@@ -1,5 +1,10 @@
 import json
+import os
+from contextlib import closing
 from urlparse import urlparse
+
+import unicodecsv
+from openpyxl import Workbook
 
 from ckanpackager.lib.ckan_resource import CkanResource
 from ckanpackager.lib.resource_file import ResourceFile
@@ -70,7 +75,7 @@ class DatastorePackageTask(PackageTask):
             self.log.info("Fetching fields")
             # read the datastore fields and determine the backend type
             fields, backend = ckan_resource.get_fields_and_backend()
-            
+
             # write fields to out file as headers
             fields = self._write_headers(resource, fields)
 
@@ -109,13 +114,49 @@ class DatastorePackageTask(PackageTask):
             w.writerow(row)
 
     def _finalize_resource(self, fields, resource):
-        """Finalize the resource before ZIPing it.
-
-        This implementation does nothing - this is available as a hook for
-        sub-classes who wish to add other files in the .zip file
+        """
+        Finalize the resource before ZIPing it. In this implementation, this only does something if
+        the requested format is xlsx in which case we convert the output csv file to xlsx format.
 
         @param fields: List
         @param resource: The resource we are creating
         @type resource: ResourceFile
         """
-        pass
+        if self.request_params.get('format') == 'xlsx':
+            # make sure the csv writer is flushed and closed
+            writer = resource.get_writer('resource.csv')
+            if not writer.closed:
+                writer.flush()
+                writer.close()
+            # remove the writer from the resource file's writers dict so that we avoid it trying to
+            # manage it after we've deleted it
+            resource.writers.pop('resource.csv')
+
+            csv_path = os.path.join(resource.working_folder, 'resource.csv')
+            xlsx_path = os.path.join(resource.working_folder, 'resource.xlsx')
+
+            # using the write only workbook avoids storing the workbook in memory and thus dodges
+            # running out of RAM, see:
+            # https://openpyxl.readthedocs.io/en/stable/optimized.html#write-only-mode.
+            # Note that there are some restrictions as to what you can do with a write only workbook
+            # but we don't run into any of them in the current implementation and we need it so that
+            # this writer doesn't eat all our RAM (as it says in the doc, RAM usage can be 50x file
+            # size! :O)
+            workbook = Workbook(write_only=True)
+            workbook.create_sheet('Data')
+            worksheet = workbook.active
+            with closing(workbook):
+                with open(csv_path, 'rb') as f:
+                    reader = unicodecsv.reader(
+                        f,
+                        encoding='utf-8',
+                        delimiter=resource.get_delimiter(),
+                        quotechar='"',
+                        lineterminator="\n"
+                    )
+                    for row in reader:
+                        worksheet.append(row)
+
+                workbook.save(xlsx_path)
+            # delete the original csv now that we're done with it
+            os.unlink(csv_path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ lxml==3.4.0
 urllib3==1.7.1
 raven==5.32.0
 bcrypt==3.1.4
+openpyxl==2.6.4


### PR DESCRIPTION
Closes https://github.com/NaturalHistoryMuseum/data-portal/issues/437.

This adds support for XLSX format downloads for datastore resources that aren't DwC requests.

Note that this is implemented in a pretty hacky way (the normal CSV is created and then converted to XLSX in the final step before zipping). This is because this service will be deprecated soon (it's still running on Python 2 and we've replaced it with something better) so it was better to add to the code (i.e. add an extra step) than modify it heavily (change how we write records so that we could directly write to a csv file or an xlsx workbook).