### PR TITLE
Add an HTML version of the download email

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ ZIP_COMMAND = "/usr/bin/zip -j {output} {input}"
 # {ckan_host}: The hostname of the CKAN server the query was made to,
 # {doi}: The DOI for this download, if there is one (if the DOI is missing, this will be blank)
 # {doi_body}: The result of formatting the DOI_BODY below with these placeholders (if the DOI is missing, will be blank)
+# {doi_body_html}: The result of formatting the DOI_BODY_HTML below with these placeholders (if the DOI is missing, will be blank)
 EMAIL_SUBJECT = "Resource from {ckan_host}"
 
 # Email FROM line. This should be an actual email address. See Email subject for placeholders.
@@ -364,9 +365,31 @@ Best Wishes,
 The Data Portal Bot
 """
 
+# Email body in html. See Email subject for placeholders.
+EMAIL_BODY_HTML = """<html lang="en">
+<body>
+<p>Hello,</p>
+<p>The link to the resource data you requested on <a href="{ckan_host}">{ckan_host}</a> is
+available at <a href="http://{ckan_host}/{zip_file_name}">here</a>.</p>
+<br />
+{doi_body_html}
+<p>Best Wishes,</p>
+<p>The Data Portal Bot</p>
+</body>
+</html>
+"""
+
 # DOI body. See Email subject for placeholders.
 DOI_BODY = """A DOI has been created for this data: https://doi.org/{doi} (this may take a few hours to become active).
-Please ensure you reference this DOI when citing this data. For more information, follow the DOI link.
+Please ensure you reference this DOI when citing this data.
+For more information, follow the DOI link.
+"""
+
+# DOI body in html message. See Email subject for placeholders.
+DOI_BODY_HTML = """<p>A DOI has been created for this data: <a href="https://doi.org/{doi}">https://doi.org/{doi}</a> (this may take a few hours to become active).</p>
+<p>Please ensure you reference this DOI when citing this data.</p>
+<p>For more information, follow the DOI link.</p>
+<br />
 """
 
 # SMTP host

--- a/ckanpackager/config_defaults.py
+++ b/ckanpackager/config_defaults.py
@@ -26,10 +26,26 @@ http://{ckan_host}/{zip_file_name}
 Best Wishes,
 The Data Portal Bot
 """
-
+EMAIL_BODY_HTML = """<html lang="en">
+<body>
+<p>Hello,</p>
+<p>The link to the resource data you requested on <a href="{ckan_host}">{ckan_host}</a> is
+available at <a href="http://{ckan_host}/{zip_file_name}">here</a>.</p>
+<br />
+{doi_body_html}
+<p>Best Wishes,</p>
+<p>The Data Portal Bot</p>
+</body>
+</html>
+"""
 DOI_BODY = """A DOI has been created for this data: https://doi.org/{doi} (this may take a few hours to become active).
 Please ensure you reference this DOI when citing this data.
 For more information, follow the DOI link.
+"""
+DOI_BODY_HTML = """<p>A DOI has been created for this data: <a href="https://doi.org/{doi}">https://doi.org/{doi}</a> (this may take a few hours to become active).</p>
+<p>Please ensure you reference this DOI when citing this data.</p>
+<p>For more information, follow the DOI link.</p>
+<br />
 """
 
 DWC_ID_FIELD = '_id'

--- a/deployment/ckanpackager_settings.py
+++ b/deployment/ckanpackager_settings.py
@@ -53,6 +53,7 @@ SUCCESS_MESSAGE = "The resource will be emailed to you shortly. This make take a
 # {ckan_host}: The hostname of the CKAN server the query was made to,
 # {doi}: The DOI for this download, if there is one (if the DOI is missing, this will be blank)
 # {doi_body}: The result of formatting the DOI_BODY below with these placeholders (if the DOI is missing, will be blank)
+# {doi_body_html}: The result of formatting the DOI_BODY_HTML below with these placeholders (if the DOI is missing, will be blank)
 EMAIL_SUBJECT = "Resource from {ckan_host}"
 
 # Email FROM line. See Email subject for placeholders.
@@ -69,11 +70,29 @@ http://www.example.com/resources/{zip_file_name}
 Best Wishes,
 The Data Portal Bot
 """
-
+# Email body in html. See Email subject for placeholders.
+EMAIL_BODY_HTML = """<html lang="en">
+<body>
+<p>Hello,</p>
+<p>The link to the resource data you requested on <a href="{ckan_host}">{ckan_host}</a> is
+available at <a href="http://www.example.com/resources/{zip_file_name}">here</a>.</p>
+<br />
+{doi_body_html}
+<p>Best Wishes,</p>
+<p>The Data Portal Bot</p>
+</body>
+</html>
+"""
 # DOI body. See Email subject for placeholders.
 DOI_BODY = """A DOI has been created for this data: https://doi.org/{doi} (this may take a few hours to become active).
 Please ensure you reference this DOI when citing this data.
 For more information, follow the DOI link.
+"""
+# DOI body in html message. See Email subject for placeholders.
+DOI_BODY_HTML = """<p>A DOI has been created for this data: <a href="https://doi.org/{doi}">https://doi.org/{doi}</a> (this may take a few hours to become active).</p>
+<p>Please ensure you reference this DOI when citing this data.</p>
+<p>For more information, follow the DOI link.</p>
+<br />
 """
 
 # SMTP host


### PR DESCRIPTION
This is the counterpart to this: https://github.com/NaturalHistoryMuseum/ckanext-versioned-datastore/pull/42.
